### PR TITLE
Updated daily cronjobs to run within first five minutes of each day

### DIFF
--- a/ar-sync.spec
+++ b/ar-sync.spec
@@ -1,6 +1,6 @@
 Name: ar-sync
 Summary: A/R Comp Engine sync scripts
-Version: 1.1.19
+Version: 1.2.1
 Release: 1%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
@@ -70,6 +70,8 @@ install --mode 644 cronjobs/hepspec %{buildroot}/etc/cron.d/hepspec
 %attr(0644,root,root) /etc/cron.d/hepspec
 
 %changelog
+* Tue Mar 18 2014 Paschalis Korosoglou <pkoro@grid.auth.gr> - 1.2.1-1%{?dist}
+- Updated daily cronjobs to run within first five minutes of each day
 * Thu Jan 30 2014 Paschalis Korosoglou <pkoro@grid.auth.gr> - 1.1.19-1%{?dist}
 - Updated daily cronjobs to run within first hour of each day
 * Tue Jan 14 2014 Paschalis Korosoglou <pkoro@grid.auth.gr> - 1.1.18-1%{?dist}

--- a/cronjobs/hepspec
+++ b/cronjobs/hepspec
@@ -1,2 +1,1 @@
-25 0 * * * root /usr/libexec/ar-sync/hepspec_sync
-
+2 0 * * * root /usr/libexec/ar-sync/hepspec_sync

--- a/cronjobs/poem
+++ b/cronjobs/poem
@@ -1,2 +1,1 @@
-20 0 * * * root /usr/libexec/ar-sync/poem-sync
-
+3 0 * * * root /usr/libexec/ar-sync/poem-sync

--- a/cronjobs/topology
+++ b/cronjobs/topology
@@ -1,1 +1,1 @@
-15 0 * * * root /usr/libexec/ar-sync/topology-sync
+4 0 * * * root /usr/libexec/ar-sync/topology-sync


### PR DESCRIPTION
The three cronjobs take seconds to complete (each) so I grouped them a bit further to be executed on the first five minutes of each day. This will assist me a bit with the automations I am planning on the compute engine side (hourly and daily calculations). 
