### PR TITLE
server certificate verify, logging refactored, bugfixes 

### DIFF
--- a/argo-egi-connectors.spec
+++ b/argo-egi-connectors.spec
@@ -1,6 +1,6 @@
 Name: argo-egi-connectors
-Version: 1.4.3
-Release: 3%{?dist}
+Version: 1.4.4
+Release: 1%{?dist}
 
 Group: EGI/SA4
 License: ASL 2.0
@@ -46,6 +46,21 @@ rm -rf $RPM_BUILD_ROOT
 %attr(0750,root,root) %dir %{_localstatedir}/log/argo-egi-connectors/
 
 %changelog
+* Fri 02-10-2015 Daniel Vrcic <dvrcic@srce.hr> - 1.4.4-1%{?dist}
+- filter SRM endpoints too
+- refactored use of logging
+- connectors can verify server certificate
+  https://github.com/ARGOeu/ARGO/issues/153
+- report correct number of fetched endpoints even if SRM endpoints were being filtered
+- connectors handle help argument and describe basic info and usage
+  https://github.com/ARGOeu/ARGO/issues/169
+- removed hardcoded scopes and grab them dynamically from config
+  https://github.com/ARGOeu/ARGO/issues/168
+- report config parser errors via logger
+- downtimes connector complain if wrong date specified
+- remove notion of default scope
+- doc moved to repo
+- updated doc with server's cert validate options
 * Wed Aug 19 2015 Daniel Vrcic <dvrcic@srce.hr> - 1.4.3-3%{?dist}
 - fix exception in case of returned HTTP 500 for other connectors
 * Sat Aug 15 2015 Daniel Vrcic <dvrcic@srce.hr> - 1.4.3-2%{?dist}

--- a/argo-egi-connectors.spec
+++ b/argo-egi-connectors.spec
@@ -11,7 +11,7 @@ Vendor: SRCE <dvrcic@srce.hr, lgjenero@gmail.com>
 Obsoletes: ar-sync
 Prefix: %{_prefix}
 Requires: avro
-Requires: pyOpenSSL 
+Requires: pyOpenSSL
 Source0: %{name}-%{version}.tar.gz
 
 BuildArch: noarch

--- a/argo-egi-connectors.spec
+++ b/argo-egi-connectors.spec
@@ -46,7 +46,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(0750,root,root) %dir %{_localstatedir}/log/argo-egi-connectors/
 
 %changelog
-* Fri 02-10-2015 Daniel Vrcic <dvrcic@srce.hr> - 1.4.4-1%{?dist}
+* Fri Oct 2 2015 Daniel Vrcic <dvrcic@srce.hr> - 1.4.4-1%{?dist}
 - filter SRM endpoints too
 - refactored use of logging
 - connectors can verify server certificate

--- a/argo-egi-connectors.spec
+++ b/argo-egi-connectors.spec
@@ -11,6 +11,7 @@ Vendor: SRCE <dvrcic@srce.hr, lgjenero@gmail.com>
 Obsoletes: ar-sync
 Prefix: %{_prefix}
 Requires: avro
+Requires: pyOpenSSL 
 Source0: %{name}-%{version}.tar.gz
 
 BuildArch: noarch

--- a/bin/downtimes-gocdb-connector.py
+++ b/bin/downtimes-gocdb-connector.py
@@ -31,10 +31,14 @@ import os
 import sys
 import xml.dom.minidom
 import copy
+import socket
+from urlparse import urlparse
 
 from argo_egi_connectors.writers import AvroWriter
 from argo_egi_connectors.writers import SingletonLogger as Logger
 from argo_egi_connectors.config import Global, CustomerConf
+from argo_egi_connectors.tools import verify_cert, errmsg_from_excp
+from OpenSSL.SSL import Error as SSLError
 
 logger = None
 
@@ -44,26 +48,19 @@ fileout = 'downtimes_%s.avro'
 
 class GOCDBReader(object):
     def __init__(self, feed):
-        self.gocdbUrl = feed
-        self.gocdbHost = self._getHostFeed(feed)
+        self.gocdbHost = urlparse(feed).netloc
         self.hostKey =  globopts['AuthenticationHostKey'.lower()]
         self.hostCert = globopts['AuthenticationHostCert'.lower()]
         self.argDateFormat = "%Y-%m-%d"
         self.WSDateFormat = "%Y-%m-%d %H:%M"
 
-    def _getHostFeed(self, feed):
-        host = feed
-        if "https://" in feed:
-            host = feed.split("https://")[1]
-            if "/" in host:
-                host = host.split('/')[0]
-        return host
-
     def getDowntimes(self, start, end):
         filteredDowntimes = list()
         try:
+            if eval(globopts['AuthenticationVerifyServerCert'.lower()]):
+                verify_cert(self.gocdbHost, globopts['AuthenticationCAPath'.lower()], 180)
             conn = httplib.HTTPSConnection(self.gocdbHost, 443, self.hostKey, self.hostCert)
-            conn.request('GET', '/gocdbpi/private/' + '?method=get_downtime&windowstart=%s&windowend=%s' % (start.strftime(self.argDateFormat), end.strftime(self.argDateFormat)))
+            conn.request('GET', '/gocdbpi/private/?method=get_downtime&windowstart=%s&windowend=%s' % (start.strftime(self.argDateFormat), end.strftime(self.argDateFormat)))
             res = conn.getresponse()
             if res.status == 200:
                 doc = xml.dom.minidom.parseString(res.read())
@@ -98,13 +95,16 @@ class GOCDBReader(object):
         except AssertionError:
             logger.error("GOCDBReader.getDowntimes():", "Error parsing feed")
             raise SystemExit(1)
+        except(SSLError, socket.error, socket.timeout) as e:
+            logger.error('Connection error %s - %s' % (self.gocdbHost, errmsg_from_excp(e)))
+            raise SystemExit(1)
 
         return filteredDowntimes
 
 def main():
     global logger
     logger = Logger(os.path.basename(sys.argv[0]))
-    certs = {'Authentication': ['HostKey', 'HostCert']}
+    certs = {'Authentication': ['HostKey', 'HostCert', 'CAPath', 'VerifyServerCert']}
     schemas = {'AvroSchemas': ['Downtimes']}
     output = {'Output': ['Downtimes']}
     cglob = Global(certs, schemas, output)

--- a/bin/downtimes-gocdb-connector.py
+++ b/bin/downtimes-gocdb-connector.py
@@ -125,9 +125,13 @@ def main():
         raise SystemExit(1)
 
     # calculate start and end times
-    start = datetime.datetime.strptime(args.date[0], '%Y-%m-%d')
-    end = datetime.datetime.strptime(args.date[0], '%Y-%m-%d')
-    timestamp = start.strftime('%Y_%m_%d')
+    try:
+        start = datetime.datetime.strptime(args.date[0], '%Y-%m-%d')
+        end = datetime.datetime.strptime(args.date[0], '%Y-%m-%d')
+        timestamp = start.strftime('%Y_%m_%d')
+    except ValueError as e:
+        logger.error(e)
+        raise SystemExit(1)
     start = start.replace(hour=0, minute=0, second=0)
     end = end.replace(hour=23, minute=59, second=59)
 

--- a/bin/downtimes-gocdb-connector.py
+++ b/bin/downtimes-gocdb-connector.py
@@ -32,7 +32,8 @@ import sys
 import xml.dom.minidom
 import copy
 
-from argo_egi_connectors.writers import AvroWriter, Logger
+from argo_egi_connectors.writers import AvroWriter
+from argo_egi_connectors.writers import SingletonLogger as Logger
 from argo_egi_connectors.config import Global, CustomerConf
 
 logger = None
@@ -144,7 +145,7 @@ def main():
 
             filename = jobdir + globopts['OutputDowntimes'.lower()] % timestamp
             avro = AvroWriter(globopts['AvroSchemasDowntimes'.lower()], filename,
-                              dts + dtslegmap, os.path.basename(sys.argv[0]), logger)
+                              dts + dtslegmap, os.path.basename(sys.argv[0]))
             avro.write()
 
 	logger.info('Fetched Date:%s Endpoints:%d' % (args.date[0], len(dts + dtslegmap)))

--- a/bin/downtimes-gocdb-connector.py
+++ b/bin/downtimes-gocdb-connector.py
@@ -116,7 +116,7 @@ def main():
     confcust.make_dirstruct()
     feeds = confcust.get_mapfeedjobs(sys.argv[0], deffeed='https://goc.egi.eu/gocdbpi/')
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description='Fetch downtimes from GOCDB for given date')
     parser.add_argument('-d', dest='date', nargs=1, metavar='YEAR-MONTH-DAY', required=True)
     args = parser.parse_args()
 

--- a/bin/prefilter-egi.py
+++ b/bin/prefilter-egi.py
@@ -24,17 +24,17 @@
 # the EGI-InSPIRE project through the European Commission's 7th
 # Framework Programme (contract # INFSO-RI-261323)
 
-import sys
-import os
-import datetime
-import avro.schema
 import argparse
+import avro.schema
+import datetime
+import os
+import sys
 import time
-from avro.datafile import DataFileReader, DataFileWriter
-from avro.io import DatumReader, DatumWriter
 
 from argo_egi_connectors.config import Global, CustomerConf
 from argo_egi_connectors.writers import Logger
+from avro.datafile import DataFileReader, DataFileWriter
+from avro.io import DatumReader, DatumWriter
 
 globopts, confcust = {}, None
 logger = None
@@ -298,7 +298,8 @@ def main():
 
     stats = ()
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="""Filters consumer logs based on various criteria
+                                                    (allowed NGIs, service flavours, metrics...)""")
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-d', dest='date', nargs=1, metavar='YEAR-MONTH-DAY')
     group.add_argument('-f', dest='cfile', nargs=1, metavar='consumer_log_YEAR-MONTH-DAY.avro')
@@ -309,8 +310,11 @@ def main():
         date = args.cfile[0].split('_')[-1]
         date = date.split('.')[0]
         date = date.split('-')
-    else:
+    elif args.date:
         date = args.date[0].split('-')
+    else:
+        parser.print_help()
+        raise SystemExit(1)
 
     if len(date) == 0 or len(date) != 3:
         logger.error('Consumer file does not end with correctly formatted date')

--- a/bin/topology-gocdb-connector.py
+++ b/bin/topology-gocdb-connector.py
@@ -49,28 +49,37 @@ globopts = {}
 logger = None
 
 class GOCDBReader:
-    def __init__(self, feed):
+    def __init__(self, feed, scopes):
         self.gocdbHost = urlparse(feed).netloc
+        self.scopes = scopes if scopes else set(['EGI'])
         self.hostKey = globopts['AuthenticationHostKey'.lower()]
         self.hostCert = globopts['AuthenticationHostCert'.lower()]
-        self.siteListEGI, self.siteListLocal = dict(), dict()
-        self.serviceListEGI, self.serviceListLocal = dict(), dict()
-        self.groupListEGI, self.groupListLocal = dict(), dict()
+        for scope in self.scopes:
+            code = "self.serviceList%s = dict(); " % scope
+            code += "self.groupList%s = dict();" % scope
+            code += "self.siteList%s = dict()" % scope
+            exec code
+        self.fetched = False
 
     def getGroupOfServices(self):
-        self.loadDataIfNeeded()
+        if not self.fetched:
+            self.loadDataIfNeeded()
 
-        groups = list()
-        for d in self.groupListEGI, self.groupListLocal:
-            key, group = d.iteritems()
-            for service in group['services']:
+        groups, gl = list(), list()
+
+        for scope in self.scopes:
+            code = "gl = gl + [value for key, value in self.groupList%s.iteritems()]" % scope
+            exec code
+
+        for d in gl:
+            for service in d['services']:
                 g = dict()
                 g['type'] = fetchtype.upper()
-                g['group'] = group['name']
+                g['group'] = d['name']
                 g['service'] = service['type']
                 g['hostname'] = service['hostname']
-                g['group_monitored'] = group['monitored']
-                g['tags'] = {'scope' : group['scope'], \
+                g['group_monitored'] = d['monitored']
+                g['tags'] = {'scope' : d['scope'], \
                             'monitored' : 1 if service['monitored'] == "Y" else 0, \
                             'production' : 1 if service['production'] == "Y" else 0}
                 groups.append(g)
@@ -78,23 +87,28 @@ class GOCDBReader:
         return groups
 
     def getGroupOfGroups(self):
-        self.loadDataIfNeeded()
+        if not self.fetched:
+            self.loadDataIfNeeded()
 
-        groupofgroups = list()
+        groupofgroups, gl = list(), list()
 
         if fetchtype == "ServiceGroups":
-            for d in self.groupListEGI, self.groupListLocal:
-                key, value = d.iteritems()
+            for scope in self.scopes:
+                code = "gl = gl + [value for key, value in self.groupList%s.iteritems()]" % scope
+                exec code
+            for d in gl:
                 g = dict()
                 g['type'] = 'PROJECT'
                 g['group'] = 'EGI'
-                g['subgroup'] = value['name']
-                g['tags'] = {'monitored' : 1 if value['monitored'] == 'Y' else 0,
-                            'scope' : value['scope']}
+                g['subgroup'] = d['name']
+                g['tags'] = {'monitored' : 1 if d['monitored'] == 'Y' else 0,
+                            'scope' : d['scope']}
                 groupofgroups.append(g)
         else:
-            gg = sorted([value for d in self.siteListEGI, self.siteListLocal for key, value in d.iteritems()],
-                                        key=lambda s: s['ngi'])
+            gg = []
+            for scope in self.scopes:
+                code = "gg = gg + sorted([value for key, value in self.siteList%s.iteritems()], key=lambda s: s['ngi'])" % scope
+                exec code
 
             for gr in gg:
                 g = dict()
@@ -110,11 +124,13 @@ class GOCDBReader:
         return groupofgroups
 
     def getGroupOfEndpoints(self):
-        self.loadDataIfNeeded()
+        if not self.fetched:
+            self.loadDataIfNeeded()
 
-        groupofendpoints = list()
-        ge = sorted([value for d in self.serviceListEGI, self.serviceListLocal for key, value in d.iteritems()],
-                                 key=lambda s: s['site'])
+        groupofendpoints, ge = list(), list()
+        for scope in self.scopes:
+            code = "ge = ge + sorted([value for key, value in self.serviceList%s.iteritems()], key=lambda s: s['site'])" % scope
+            exec code
 
         for gr in ge:
             g = dict()
@@ -131,17 +147,12 @@ class GOCDBReader:
 
     def loadDataIfNeeded(self):
         try:
-            if len(self.siteListEGI) == 0:
-                self.getSitesInternal(self.siteListEGI, 'EGI')
-                self.getSitesInternal(self.siteListLocal, 'Local')
+            for scope in self.scopes:
+                eval("self.getSitesInternal(self.siteList%s, '&scope='+scope)" % scope)
+                eval("self.getServiceGroups(self.groupList%s, '&scope='+scope)" % scope)
+                eval("self.getServiceEndpoints(self.serviceList%s, '&scope='+scope)" % scope)
+                self.fetched = True
 
-            if len(self.serviceListEGI) == 0:
-                self.getServiceEndpoints(self.serviceListEGI, 'EGI')
-                self.getServiceEndpoints(self.serviceListLocal, 'Local')
-
-            if len(self.groupListEGI) == 0:
-                self.getServiceGroups(self.groupListEGI, 'EGI')
-                self.getServiceGroups(self.groupListLocal, 'Local')
         except (socket.error, httplib.HTTPException) as e:
             logger.error('Connection to GOCDB failed: ' + str(e))
             raise SystemExit(1)
@@ -151,7 +162,7 @@ class GOCDBReader:
             if eval(globopts['AuthenticationVerifyServerCert'.lower()]):
                 verify_cert(self.gocdbHost, globopts['AuthenticationCAPath'.lower()], 180)
             conn = httplib.HTTPSConnection(self.gocdbHost, 443, self.hostKey, self.hostCert)
-            conn.request('GET', '/gocdbpi/private/?method=get_service_endpoint&scope=' + scope)
+            conn.request('GET', '/gocdbpi/private/?method=get_service_endpoint' + scope)
             res = conn.getresponse()
             if res.status == 200:
                 doc = xml.dom.minidom.parseString(res.read())
@@ -169,13 +180,13 @@ class GOCDBReader:
                     serviceList[serviceId]['production'] = service.getElementsByTagName('IN_PRODUCTION')[0].childNodes[0].data
                     serviceList[serviceId]['site'] = service.getElementsByTagName('SITENAME')[0].childNodes[0].data
                     serviceList[serviceId]['roc'] = service.getElementsByTagName('ROC_NAME')[0].childNodes[0].data
-                    serviceList[serviceId]['scope'] = scope
+                    serviceList[serviceId]['scope'] = scope.split('=')[1]
                     serviceList[serviceId]['sortId'] = serviceList[serviceId]['hostname'] + '-' + serviceList[serviceId]['type'] + '-' + serviceList[serviceId]['site']
             else:
                 logger.error('GOCDBReader.getServiceEndpoints(): HTTP response: %s %s' % (str(res.status), res.reason))
                 raise SystemExit(1)
         except AssertionError:
-            logger.error("GOCDBReader.getServiceEndpoints():", "Error parsing feed")
+            logger.error("GOCDBReader.getServiceEndpoints(): Error parsing feed")
             raise SystemExit(1)
         except(SSLError, socket.error, socket.timeout) as e:
             logger.error('Connection error %s - %s' % (self.gocdbHost, errmsg_from_excp(e)))
@@ -186,7 +197,7 @@ class GOCDBReader:
             if eval(globopts['AuthenticationVerifyServerCert'.lower()]):
                 verify_cert(self.gocdbHost, globopts['AuthenticationCAPath'.lower()], 180)
             conn = httplib.HTTPSConnection(self.gocdbHost, 443, self.hostKey, self.hostCert)
-            conn.request('GET', '/gocdbpi/private/?method=get_site&scope=' + scope)
+            conn.request('GET', '/gocdbpi/private/?method=get_site'+scope)
             res = conn.getresponse()
             if res.status == 200:
                 dom = xml.dom.minidom.parseString(res.read())
@@ -199,12 +210,12 @@ class GOCDBReader:
                     siteList[siteName]['infrastructure'] = site.getElementsByTagName('PRODUCTION_INFRASTRUCTURE')[0].childNodes[0].data
                     siteList[siteName]['certification'] = site.getElementsByTagName('CERTIFICATION_STATUS')[0].childNodes[0].data
                     siteList[siteName]['ngi'] = site.getElementsByTagName('ROC')[0].childNodes[0].data
-                    siteList[siteName]['scope'] = scope
+                    siteList[siteName]['scope'] = scope.split('=')[1]
             else:
                 logger.error('GOCDBReader.getSitesInternal(): HTTP response: %s %s' % (str(res.status), res.reason))
                 raise SystemExit(1)
         except AssertionError:
-            logger.error("GOCDBReader.getSitesInternal():", "Error parsing feed")
+            logger.error("GOCDBReader.getSitesInternal(): Error parsing feed")
             raise SystemExit(1)
         except(SSLError, socket.error, socket.timeout) as e:
             logger.error('Connection error %s - %s' % (self.gocdbHost, errmsg_from_excp(e)))
@@ -215,7 +226,7 @@ class GOCDBReader:
             if eval(globopts['AuthenticationVerifyServerCert'.lower()]):
                 verify_cert(self.gocdbHost, globopts['AuthenticationCAPath'.lower()], 180)
             conn = httplib.HTTPSConnection(self.gocdbHost, 443, self.hostKey, self.hostCert)
-            conn.request('GET', '/gocdbpi/private/?method=get_service_group&scope=' + scope)
+            conn.request('GET', '/gocdbpi/private/?method=get_service_group' + scope)
             res = conn.getresponse()
             if res.status == 200:
                 doc = xml.dom.minidom.parseString(res.read())
@@ -227,7 +238,7 @@ class GOCDBReader:
                         groupList[groupId] = {}
                     groupList[groupId]['name'] = group.getElementsByTagName('NAME')[0].childNodes[0].data
                     groupList[groupId]['monitored'] = group.getElementsByTagName('MONITORED')[0].childNodes[0].data
-                    groupList[groupId]['scope'] = scope
+                    groupList[groupId]['scope'] = scope.split('=')[1]
                     groupList[groupId]['services'] = []
                     services = group.getElementsByTagName('SERVICE_ENDPOINT')
                     for service in services:
@@ -241,7 +252,7 @@ class GOCDBReader:
                 logger.error('GOCDBReader.getServiceGroups(): HTTP response: %s %s' % (str(res.status), res.reason))
                 raise SystemExit(1)
         except AssertionError:
-            logger.error("GOCDBReader.getServiceGroups():", "Error parsing feed")
+            logger.error("GOCDBReader.getServiceGroups(): Error parsing feed")
             raise SystemExit(1)
         except(SSLError, socket.error, socket.timeout) as e:
             logger.error('Connection error %s - %s' % (self.gocdbHost, errmsg_from_excp(e)))
@@ -253,8 +264,14 @@ def filter_by_tags(tags, listofelem):
             value = elem['tags'][attr.lower()]
             if isinstance(value, int):
                 value = 'Y' if value else 'N'
-            if value.lower() == tags[attr].lower():
-                return True
+            if isinstance(tags[attr], list):
+                for a in tags[attr]:
+                    if value.lower() == a.lower():
+                        return True
+            else:
+                if value.lower() == tags[attr].lower():
+                    return True
+
         listofelem = filter(getit, listofelem)
     return listofelem
 
@@ -278,12 +295,13 @@ def main():
     confcust = CustomerConf(sys.argv[0])
     confcust.parse()
     confcust.make_dirstruct()
+    scopes = confcust.get_allspec_scopes(sys.argv[0], 'GOCDB')
     feeds = confcust.get_mapfeedjobs(sys.argv[0], 'GOCDB', deffeed='https://goc.egi.eu/gocdbpi/')
 
     timestamp = datetime.datetime.utcnow().strftime('%Y_%m_%d')
 
     for feed, jobcust in feeds.items():
-        gocdb = GOCDBReader(feed)
+        gocdb = GOCDBReader(feed, scopes)
 
         for job, cust in jobcust:
             jobdir = confcust.get_fulldir(cust, job)
@@ -328,11 +346,15 @@ def main():
                 selge, selgg = '', ''
                 if getags:
                     for key, value in getags.items():
+                        if isinstance(value, list):
+                            value = '['+','.join(value)+']'
                         selge += '%s:%s,' % (key, value)
                     selstr += 'Endpoints(%s):' % selge[:len(selge) - 1]
                     selstr += '%d ' % (len(group_endpoints) + len(gelegmap))
                 if ggtags:
                     for key, value in ggtags.items():
+                        if isinstance(value, list):
+                            value = '['+','.join(value)+']'
                         selgg += '%s:%s,' % (key, value)
                     selstr += 'Groups(%s):' % selgg[:len(selgg) - 1]
                     selstr += '%d' % (len(group_groups))

--- a/bin/topology-gocdb-connector.py
+++ b/bin/topology-gocdb-connector.py
@@ -308,6 +308,7 @@ def main():
                     gelegmap.append(copy.copy(g))
                     gelegmap[-1]['service'] = LegMapServType[g['service']]
             getags = confcust.get_gocdb_getags(job)
+            numgeleg = len(gelegmap)
             if getags:
                 group_endpoints = filter_by_tags(getags, group_endpoints)
                 gelegmap = filter_by_tags(getags, gelegmap)
@@ -316,7 +317,7 @@ def main():
                             group_endpoints + gelegmap, os.path.basename(sys.argv[0]))
             avro.write()
 
-            logger.info('Job:'+job+' Fetched Endpoints:%d' % (numge + len(gelegmap))+' Groups(%s):%d' % (fetchtype, numgg))
+            logger.info('Job:'+job+' Fetched Endpoints:%d' % (numge + numgeleg) +' Groups(%s):%d' % (fetchtype, numgg))
             if getags or ggtags:
                 selstr = 'Job:%s Selected ' % (job)
                 selge, selgg = '', ''

--- a/bin/topology-gocdb-connector.py
+++ b/bin/topology-gocdb-connector.py
@@ -51,7 +51,7 @@ logger = None
 class GOCDBReader:
     def __init__(self, feed, scopes):
         self.gocdbHost = urlparse(feed).netloc
-        self.scopes = scopes if scopes else set(['EGI'])
+        self.scopes = scopes if scopes else set(['NoScope'])
         self.hostKey = globopts['AuthenticationHostKey'.lower()]
         self.hostCert = globopts['AuthenticationHostCert'.lower()]
         for scope in self.scopes:
@@ -147,10 +147,11 @@ class GOCDBReader:
 
     def loadDataIfNeeded(self):
         try:
+            scopequery = "'&scope='+scope"
             for scope in self.scopes:
-                eval("self.getSitesInternal(self.siteList%s, '&scope='+scope)" % scope)
-                eval("self.getServiceGroups(self.groupList%s, '&scope='+scope)" % scope)
-                eval("self.getServiceEndpoints(self.serviceList%s, '&scope='+scope)" % scope)
+                eval("self.getSitesInternal(self.siteList%s, %s)" % (scope, '' if scope == 'NoScope' else scopequery))
+                eval("self.getServiceGroups(self.groupList%s, %s)" % (scope, '' if scope == 'NoScope' else scopequery))
+                eval("self.getServiceEndpoints(self.serviceList%s, %s)" % (scope, '' if scope == 'NoScope' else scopequery))
                 self.fetched = True
 
         except (socket.error, httplib.HTTPException) as e:

--- a/bin/topology-gocdb-connector.py
+++ b/bin/topology-gocdb-connector.py
@@ -34,7 +34,8 @@ import socket
 import copy
 from exceptions import AssertionError
 
-from argo_egi_connectors.writers import AvroWriter, Logger
+from argo_egi_connectors.writers import AvroWriter
+from argo_egi_connectors.writers import SingletonLogger as Logger
 from argo_egi_connectors.config import Global, CustomerConf
 
 
@@ -290,7 +291,7 @@ def main():
                 group_groups = filter_by_tags(ggtags, group_groups)
             filename = jobdir+globopts['OutputTopologyGroupOfGroups'.lower()] % timestamp
             avro = AvroWriter(globopts['AvroSchemasTopologyGroupOfGroups'.lower()], filename,
-                            group_groups, os.path.basename(sys.argv[0]), logger)
+                            group_groups, os.path.basename(sys.argv[0]))
             avro.write()
 
             gelegmap = []
@@ -304,7 +305,7 @@ def main():
                 gelegmap = filter_by_tags(getags, gelegmap)
             filename = jobdir+globopts['OutputTopologyGroupOfEndpoints'.lower()] % timestamp
             avro = AvroWriter(globopts['AvroSchemasTopologyGroupOfEndpoints'.lower()], filename,
-                            group_endpoints + gelegmap, os.path.basename(sys.argv[0]), logger)
+                            group_endpoints + gelegmap, os.path.basename(sys.argv[0]))
             avro.write()
 
             logger.info('Job:'+job+' Fetched Endpoints:%d' % (numge + len(gelegmap))+' Groups(%s):%d' % (fetchtype, numgg))

--- a/bin/topology-gocdb-connector.py
+++ b/bin/topology-gocdb-connector.py
@@ -24,21 +24,22 @@
 # the EGI-InSPIRE project through the European Commission's 7th
 # Framework Programme (contract # INFSO-RI-261323)
 
+import argparse
+import copy
 import datetime
-import xml.dom.minidom
 import httplib
-import sys
 import os
 import socket
-import copy
-from urlparse import urlparse
-from exceptions import AssertionError
+import sys
+import xml.dom.minidom
 
-from argo_egi_connectors.writers import AvroWriter
-from argo_egi_connectors.tools import verify_cert, errmsg_from_excp
-from argo_egi_connectors.writers import SingletonLogger as Logger
-from argo_egi_connectors.config import Global, CustomerConf
 from OpenSSL.SSL import Error as SSLError
+from argo_egi_connectors.config import Global, CustomerConf
+from argo_egi_connectors.tools import verify_cert, errmsg_from_excp
+from argo_egi_connectors.writers import AvroWriter
+from argo_egi_connectors.writers import SingletonLogger as Logger
+from exceptions import AssertionError
+from urlparse import urlparse
 
 
 LegMapServType = {'SRM' : 'SRMv2'}
@@ -258,6 +259,10 @@ def filter_by_tags(tags, listofelem):
     return listofelem
 
 def main():
+    parser = argparse.ArgumentParser(description="""Fetch wanted entities (ServiceGroups, Sites, Endpoints)
+                                                    from GOCDB for every job listed in customer.conf and write them
+                                                    in an appropriate place""")
+    args = parser.parse_args()
     group_endpoints, group_groups = [], []
 
     global logger

--- a/bin/topology-gocdb-connector.py
+++ b/bin/topology-gocdb-connector.py
@@ -276,7 +276,7 @@ def filter_by_tags(tags, listofelem):
     return listofelem
 
 def main():
-    parser = argparse.ArgumentParser(description="""Fetch wanted entities (ServiceGroups, Sites, Endpoints)
+    parser = argparse.ArgumentParser(description="""Fetch entities (ServiceGroups, Sites, Endpoints)
                                                     from GOCDB for every job listed in customer.conf and write them
                                                     in an appropriate place""")
     args = parser.parse_args()

--- a/bin/topology-gocdb-connector.py
+++ b/bin/topology-gocdb-connector.py
@@ -301,6 +301,7 @@ def main():
             getags = confcust.get_gocdb_getags(job)
             if getags:
                 group_endpoints = filter_by_tags(getags, group_endpoints)
+                gelegmap = filter_by_tags(getags, gelegmap)
             filename = jobdir+globopts['OutputTopologyGroupOfEndpoints'.lower()] % timestamp
             avro = AvroWriter(globopts['AvroSchemasTopologyGroupOfEndpoints'.lower()], filename,
                             group_endpoints + gelegmap, os.path.basename(sys.argv[0]), logger)

--- a/bin/topology-vo-connector.py
+++ b/bin/topology-vo-connector.py
@@ -175,7 +175,9 @@ def main():
                 selstr = 'Job:%s Selected ' % (job)
                 selgg = ''
                 for key, value in tags.items():
-                    selgg += '%s:%s,' % (key, ','.join(value))
+                    if isinstance(value, list):
+                        value = ','.join(value)
+                    selgg += '%s:%s,' % (key, value)
                 selstr += 'Groups(%s):' % selgg[:len(selgg) - 1]
                 selstr += '%d' % (len(filtlgroups))
 

--- a/bin/topology-vo-connector.py
+++ b/bin/topology-vo-connector.py
@@ -24,7 +24,8 @@
 # the EGI-InSPIRE project through the European Commission's 7th
 # Framework Programme (contract # INFSO-RI-261323)
 
-from argo_egi_connectors.writers import AvroWriter, Logger
+from argo_egi_connectors.writers import AvroWriter
+from argo_egi_connectors.writers import SingletonLogger as Logger
 from argo_egi_connectors.config import Global, CustomerConf
 from exceptions import AssertionError
 import datetime
@@ -148,7 +149,7 @@ def main():
 
             filename = jobdir + globopts['OutputTopologyGroupOfGroups'.lower()] % timestamp
             avro = AvroWriter(globopts['AvroSchemasTopologyGroupOfGroups'.lower()], filename, filtlgroups,
-                              os.path.basename(sys.argv[0]), logger)
+                              os.path.basename(sys.argv[0]))
             avro.write()
 
             filename = jobdir + globopts['OutputTopologyGroupOfEndpoints'.lower()] % timestamp
@@ -160,7 +161,7 @@ def main():
                     gelegmap.append(copy.copy(g))
                     gelegmap[-1]['service'] = LegMapServType[g['service']]
             avro = AvroWriter(globopts['AvroSchemasTopologyGroupOfEndpoints'.lower()], filename, group_endpoints + gelegmap,
-                                                                                       os.path.basename(sys.argv[0]), logger)
+                                                                                       os.path.basename(sys.argv[0]))
             avro.write()
 
             logger.info('Job:'+job+' Fetched Endpoints:%d' % (numge + len(gelegmap))+' Groups:%d' % (numgg))

--- a/bin/topology-vo-connector.py
+++ b/bin/topology-vo-connector.py
@@ -25,20 +25,22 @@
 # Framework Programme (contract # INFSO-RI-261323)
 
 from OpenSSL.SSL import Error as SSLError
-from argo_egi_connectors.writers import AvroWriter
-from argo_egi_connectors.writers import SingletonLogger as Logger
 from argo_egi_connectors.config import Global, CustomerConf
 from argo_egi_connectors.tools import verify_cert, errmsg_from_excp
+from argo_egi_connectors.writers import AvroWriter
+from argo_egi_connectors.writers import SingletonLogger as Logger
 from exceptions import AssertionError
+from urlparse import urlparse
+
+import argparse
+import copy
 import datetime
 import httplib
-import re
-import sys
-import socket
 import os
-from urlparse import urlparse
+import re
+import socket
+import sys
 import xml.dom.minidom
-import copy
 
 
 LegMapServType = {'SRM' : 'SRMv2', 'SRMv2': 'SRM'}
@@ -112,6 +114,10 @@ class VOReader:
 
 
 def main():
+    parser = argparse.ArgumentParser(description="""Fetch wanted entities from VO feed provided in customer.conf
+                                                    and write them in an appropriate place""")
+    args = parser.parse_args()
+
     global logger
     logger = Logger(os.path.basename(sys.argv[0]))
 

--- a/bin/weights-gstat-connector.py
+++ b/bin/weights-gstat-connector.py
@@ -33,7 +33,8 @@ import sys
 from avro.datafile import DataFileReader
 from avro.io import DatumReader
 
-from argo_egi_connectors.writers import AvroWriter, Logger
+from argo_egi_connectors.writers import AvroWriter
+from argo_egi_connectors.writers import SingletonLogger as Logger
 from argo_egi_connectors.config import Global, CustomerConf
 
 globopts = {}
@@ -141,12 +142,12 @@ def main():
 
             filename = jobdir + globopts['OutputWeights'.lower()] % timestamp
             datawr = gen_outdict(newData)
-            avro = AvroWriter(globopts['AvroSchemasWeights'.lower()], filename, datawr, os.path.basename(sys.argv[0]), logger)
+            avro = AvroWriter(globopts['AvroSchemasWeights'.lower()], filename, datawr, os.path.basename(sys.argv[0]))
             avro.write()
 
             if oldDataExists:
                 datawr = gen_outdict(oldData)
-                avro = AvroWriter(globopts['AvroSchemasWeights'.lower()], filename, datawr, os.path.basename(sys.argv[0]), logger)
+                avro = AvroWriter(globopts['AvroSchemasWeights'.lower()], filename, datawr, os.path.basename(sys.argv[0]))
                 avro.write()
 
         logger.info('Jobs:%d Sites:%d' % (len(jobcust), len(datawr)))

--- a/bin/weights-gstat-connector.py
+++ b/bin/weights-gstat-connector.py
@@ -24,23 +24,23 @@
 # the EGI-InSPIRE project through the European Commission's 7th
 # Framework Programme (contract # INFSO-RI-261323)
 
-import urllib2
-import os
+import argparse
+import datetime
 import httplib
 import json
-import datetime
-import sys
+import os
 import socket
-from urlparse import urlparse
+import sys
+import urllib2
 
-from avro.datafile import DataFileReader
-from avro.io import DatumReader
-
-from argo_egi_connectors.writers import AvroWriter
-from argo_egi_connectors.writers import SingletonLogger as Logger
+from OpenSSL.SSL import Error as SSLError
 from argo_egi_connectors.config import Global, CustomerConf
 from argo_egi_connectors.tools import verify_cert, errmsg_from_excp
-from OpenSSL.SSL import Error as SSLError
+from argo_egi_connectors.writers import AvroWriter
+from argo_egi_connectors.writers import SingletonLogger as Logger
+from avro.datafile import DataFileReader
+from avro.io import DatumReader
+from urlparse import urlparse
 
 globopts = {}
 logger = None
@@ -99,8 +99,11 @@ def loadOldData(directory, timestamp):
 
     return oldDataDict
 
-
 def main():
+    parser = argparse.ArgumentParser(description="""Fetch weights information from Gstat provider
+                                                    for every job listed in customer.conf""")
+    args = parser.parse_args()
+
     global logger
     logger = Logger(os.path.basename(sys.argv[0]))
 

--- a/doc/sync.md
+++ b/doc/sync.md
@@ -58,10 +58,12 @@ Config file is read by _every_ component because every component needs to, at le
 Every component generates output file in an avro binary format. This section points to a directory that holds all avro schemas. 
 
 	[Authentication]
+	VerifyServerCert = False
+	CAPAth = /etc/grid-security/certificates
 	HostKey = /etc/grid-security/hostkey.pem
 	HostCert = /etc/grid-security/hostcert.pem
 
-Each component that talks to GOCDB or POEM peer authenticates itself with a host certificate.
+Each component that talks to GOCDB or POEM peer authenticates itself with a host certificate. `HostKey` indicates the private and `HostCert` indicates the public part of certificate. Additionally, server certificate can be validated rounding up the mutual authentication. `CAPath` contains certificates of authorities from which chain will be tried to be built upon validating.
 
 	[AvroSchemas]
 	Downtimes = %(SchemaDir)s/downtimes.avsc
@@ -314,7 +316,7 @@ With all these informations written in `PrefilterPoem` file, `prefilter-egi.py` 
 	TopoType = GOCDB
 	TopoFetchType = ServiceGroups
 	TopoSelectGroupOfEndpoints = Monitored:Y, Scope:EGI, Production:N
-	#TopoSelectGroupOfGroups = Monitored:Y, Scope:EGI
+	#TopoSelectGroupOfGroups = Monitored:Y, Scope:EGI, Certification:(Certified,Candidate)
 
 	[JOB_BioMedCritical]
 	Dirname = BioMed_Critical
@@ -449,5 +451,8 @@ Connectors are using following GOCDB PI methods:
 - [GOCDB - get_service_endpoint_method](https://wiki.egi.eu/wiki/GOCDB/PI/get_service_endpoint_method)
 - [GOCDB - get_service_group](https://wiki.egi.eu/wiki/GOCDB/PI/get_service_group)
 - [GOCDB - get_site_method](https://wiki.egi.eu/wiki/GOCDB/PI/get_site_method)
+
+`poem-connector.py` is using POEM PI method:
+- [POEM - metrics_in_profiles](http://argoeu.github.io/guides/poem/)
 
 [Construction of VO feeds](https://twiki.cern.ch/twiki/bin/view/Main/ATPVOFeeds)

--- a/doc/sync.md
+++ b/doc/sync.md
@@ -1,0 +1,453 @@
+---
+title: EGI connectors | ARGO
+page_title: EGI connectors
+font_title: 'fa fa-refresh'
+description: This document describes the available connectors for data in EGI infrastructure.
+---
+
+## Description
+
+`argo-egi-connectors` is a bundle of connectors/sync components for various data sources established in EGI infrastructure, most notably GOCDB (EGI topology, downtimes), but there's also support for fetching alternative EGI topology via various VO feeds, weights information via GStat service and POEM metric profiles.
+
+Bundle consists of the following connectors: 
+
+ - `topology-gocdb-connector.py` 
+ - `topology-vo-connector.py` 
+ - `downtimes-gocdb-connector.py` 
+ - `weights-gstat-connector.py` 
+ - `poem-connector.py`
+ - `prefilter-egy.py`: component whose role is to filter out the messages coming from the `argo-egi-consumer`.
+
+
+Connectors are syncing data on a daily basis. They are aware of the certain customer, associated jobs and their attributes and are generating and placing files into appropriate job folders. Data is written in a binary avro formated file which is suitable for processing at compute side. Topology, downtimes, weights and POEM profile information all together with a prefiltered metric results (status messages), represents an input for `argo-compute-engine`.
+
+## Installation
+
+Installation narrows down to simply installing the package:
+	
+	`yum -y install argo-egi-connectors`
+
+**`Components require avro package to be installed/available.`**
+
+
+| File Types | Destination |
+| Configuration files|  `/etc/argo-egi-connectors`|
+| Components|  `/usr/libexec/argo-egi-connectors`|
+| Cronjobs (configured to be executed once per day) | `/etc/cron.d` |
+| Directory where components will put their files| `/var/lib/argo-connectors/EGI`|
+
+## Configuration
+
+Configuration of all components is centered around two configuration files: `global.conf` and `customer.conf`. Those files contains some shared config options and sections and are _read by every component_. There's also a third one `poem-connector.conf`, specific only for `poem-connector.py` because it needs some special treatment not available in first two's.
+
+| Configuration file | Description | Shortcut |
+| `global.conf` | Config file is read by every component because every component needs to fetch host certificate to authenticate to a peer and to find correct avro schema. |<a href="#sync1">Description</a>|
+| `customer.conf` | This configuration file lists all EGI jobs, their attributes and also all VOes and theirs set of jobs and attributes. | <a href="#sync2">Description</a>|
+| `poem-connector.conf` | This configuration file is central configuration for poem-connector.py | <a href="#sync3">Description</a>|
+
+
+<a id="sync1"></a>
+
+### global.conf
+
+Config file is read by _every_ component because every component needs to, at least, fetch host certificate to authenticate to a peer and to find correct avro schema. Additionally, some connectors have default sources of data specified that can be overidden in a next configuration file. Config options are case insensitive and whole config file is splitted into a few sections:
+
+	[DEFAULT]
+	SchemaDir = /etc/argo-egi-connectors/schemas/
+
+Every component generates output file in an avro binary format. This section points to a directory that holds all avro schemas. 
+
+	[Authentication]
+	HostKey = /etc/grid-security/hostkey.pem
+	HostCert = /etc/grid-security/hostcert.pem
+
+Each component that talks to GOCDB or POEM peer authenticates itself with a host certificate.
+
+	[AvroSchemas]
+	Downtimes = %(SchemaDir)s/downtimes.avsc
+	Poem = %(SchemaDir)s/metric_profiles.avsc
+	Prefilter = %(SchemaDir)s/metric_data.avsc
+	TopologyGroupOfEndpoints = %(SchemaDir)s/group_endpoints.avsc
+	TopologyGroupOfGroups = %(SchemaDir)s/group_groups.avsc
+	Weights = %(SchemaDir)s/weight_sites.avsc
+
+This section, together with a `[DEFAULT]` section, constitutes the full path of avro schema file for each component. Avro schema files define the format of the data that each component is writing. `Topology*` schemas are common to `topology-gocdb-connector.py` and `topology-vo-connector.py` because there is a need of compute side to not make a difference between two topologies. `Prefilter` schema is taken from `argo-egi-consumer` since `prefilter-egi.py` filters its metric results and needs to write them in the same format.
+
+	[Output]
+	Downtimes = downtimes_%s.avro
+	Poem = poem_sync_%s.avro
+	Prefilter = prefilter_%s.avro
+	PrefilterConsumerFilePath = /var/lib/ar-consumer/ar-consumer_log_%s.avro
+	PrefilterPoem = poem_sync_%s.out
+	PrefilterPoemNameMapping = poem_name_mapping.cfg
+	TopologyGroupOfEndpoints = group_endpoints_%s.avro
+	TopologyGroupOfGroups = group_groups_%s.avro
+	Weights = weights_%s.avro
+
+Section lists all the filenames that each component is generating. Directory is purposely omitted because it's implicitly found in next configuration file. Exception is a `PrefilterConsumerFilePath` and `PrefilterPoem` options that tells the `prefilter-egi.py` where to look for its input files. `%s` is a string placeholder that will be replaced by the date timestamp in format `year_month_day`.
+
+<a id="sync2"></a>
+
+### customer.conf
+
+This configuration file lists all customers, their jobs and appropriate attributes. Job is presented to `argo-compute-engine` as a folder with a set of files that are generated each day and that directs compute engine what metric results to take into account and do calculations upon them. 
+
+#### Directory structure
+
+Job folders for each customer are placed under the customer's `OutputDir` directory and appropriate directory names are read from the config file. Segment of configuration file that reflects the creation of directories is for example: 
+
+	[CUSTOMER_C1]
+	OutputDir = /var/lib/argo-connectors/Customer1
+	Jobs = JOB_Test1, JOB_Test2
+
+	[JOB_Test1]
+	Dirname = C1Testing1
+
+	[JOB_Test2]
+	Dirname = C2Testing2
+
+
+	[CUSTOMER_C2]
+	OutputDir = /var/lib/argo-connectors/Customer2
+	Jobs = Job_Test3, JOB_Test4
+
+	[JOB_Test3]
+	Dirname = C2Testing1
+
+	[JOB_Test4]
+	Dirname = C2Testing2
+
+This will result in the following jobs directories:
+
+	/var/lib/argo-connectors/Customer1/C1Testing1
+	/var/lib/argo-connectors/Customer1/C1Testing2
+	/var/lib/argo-connectors/Customer2/C2Testing1
+	/var/lib/argo-connectors/Customer2/C2Testing2
+
+So there are two customers, C1 and C2, each one identified with its `[CUSTOMER_*]` section. `CUSTOMER_` is a section keyword and must be specified when one wants to define a new customer. Each customer has two mandatory options: `OutputDir` and `Jobs`. With `OutputDir` option, customer defines his directory where he'll write job folders and other data. Customer must also specify set of jobs listed in `Jobs` options since it can not exist without associated jobs. The name of the job folder is specified with `Dirname` option of the certain job so `JOB\_Test1`, identified with `[JOB_Test1]` section, will be named `C1Testing1` and it will be placed under customer's `/var/lib/argo-connectors/Customer1/` directory. Each component will firstly try to create described directory structure if it doesn't exist yet. Only afterward it will write its data. 
+
+Every connector reads this configuration file because it needs to find out how many customers are there and what are theirs customer and job directory names where they will lay down its files. So `poem-connector.py`, `downtimes-gocdb-connector.py`, `weights-gstat-connector.py`, all of them are writing theirs data in each job directory for each customer. Topology for EGI (fetched from GOCDB) is different than one for the VO so exceptions to this are `topology-gocdb-connector.py` and `topology-vo-connector.py`. They are writing data for a job based on the job's topology type specified with `TopoType` attribute.
+
+#### Job attributes
+
+Besides `Dirname` option that is common for all connectors, some of them have job attributes that are relevant only for them and upon which they are changing their behaviour. Some of those attributes are _mandatory_ like `Profiles` and `TopoType` and the other ones like `TopoSelect*` attributes are optional. Furthermore, as there are two kind of topologies, there are also two set of job attributes and values.
+
+##### GOCDB topology
+
+	[JOB_EGICloudmon]
+	Dirname = EGI_Cloudmon
+	Profiles = CLOUD-MON
+	TopoType = GOCDB
+	TopoFeed = https://goc.egi.eu/gocdbpi/
+	TopoFetchType = ServiceGroups
+	TopoSelectGroupOfEndpoints = Monitored:Y, Scope:EGI, Production:Y
+	TopoSelectGroupOfGroups = Monitored:Y, Scope:EGI
+
+This is an example of the job that fetchs topology from GOCDB since `TopoType` attribute is set to `GOCDB`. `Profiles` is an attribute relevant to `poem-connector.py` so for this job `poem-connector.py` will write CLOUD-MON profile in EGI_Cloudmon job folder under /EGI directory. `Topo*` attributes are relevant for `topology-gocdb-connector.py`. `TopoFeed` attribute in the context of the GOCDB topology is optional. If it's specified, it will override default source of topology which is https://goc.egi.eu/gocdbpi/
+
+Topology is separated in two abstracts:
+
+- group of groups
+- group of service endpoints
+
+Service endpoints are grouped either by the means of _Sites_ or _Service groups_. Those are listed and represented as an upper level abstract of group of service endpoints - group of groups. Customer can fetch either _Sites_ and their corresponding endpoints or _Service groups_ and their corresponding endpoints per job, but not both of them. What is being fetched is specified with `TopoFetchType` option/job attribute. For each abstract there will be written `TopologyGroupOfGroups` and `TopologyGroupOfEndpoints` filenames (specified in `global.conf`) into appropriate job folder. `TopoSelectGroupOfGroups` and `TopoSelectGroupOfEndpoints` options are used for further filtering. Values are set of tags used for picking up matching entity existing in the given abstract. Tags for group of groups are different for Sites and Service groups. In contrary, set of tags for groups of endpoints remains the same no matter what type of fetch customer specified.
+
+So, in a `TopoFetchType` option customer can either specify:
+
+- `ServiceGroups` - to fetch Service groups
+- `Sites` - to fetch Sites
+
+###### Tags
+
+Tags represent a fine-grained control of what is being written in output files. It's a convenient way of selecting only certain entities, being it Sites, Service groups or Service endpoints based on appropriate criteria. Tags are optional so if a certain tag for a corresponding entity is omitted, than filtering is not done. In that case, it can be considered that entity is fetched for all its values of an omitted tag.
+
+Group of group tags are different for a different type of fetch. Tags and values for a different entities are:
+
+**Sites**
+
+* Certification = `{Certified, Uncertified, Closed, Suspended, Candidate}`
+* Infrastructure = `{Production, Test}`
+* Scope = `{EGI, Local}`
+
+**ServiceGroups**
+
+* Monitored = `{Y, N}`
+* Scope = `{EGI, Local}`
+
+Tags for selecting group of endpoints are:
+
+**Service Endpoints**
+
+* Production = `{Y, N}`
+* Monitored = `{Y, N}`
+* Scope = `{EGI, Local}`
+
+##### VO topology
+
+	[DEFAULT]
+	BioMed = http://kosjenka.srce.hr/~eimamagi/ops.feed.xml
+
+	[JOB_BioMedCritical]
+	Dirname = BioMed_Critical
+	Profiles = ROC_CRITICAL
+	TopoType = VOFeed
+	TopoFeed = %(BioMed)s
+	TopoSelectGroupOfGroups = Type:(OPS_Tier, OPS_Site)
+
+This is an example of the job that is fetching topology from provided VO feed since `TopoType` attribute is set to `VOFeed`. Again, `Profiles` attribute is mandatory and is relevant to `poem-connector.py` which will write ROC\_CRITICAL profile in BioMed\_Critical job folder. `Topo*` attributes are relevant for `topology-vo-connector.py`. Contrary to GOCDB topology jobs, `TopoFeed` attribute for jobs dealing with the VO topology is _mandatory_ and must be specified. Although same topology feed can be specified across multiple jobs, internally, data from one feed is fetched only once and is further filtered and written for every job. 
+
+VO topology is also separated and written in two abstracts, group of groups and group of service endpoints, but there are no tags since VO itself filters and handles what sites and service endpoints to take into account and defines the VO groups they belong to. With that being said, there is a `TopoSelectGroupOfGroups` option available which is used to pick up VO groups based on their type. VO groups are entities existing in the group of group abstract of topology. In the example above, `topology-vo-connector.py` will pick up VO groups that match `OPS_Site` and `OPS_Tier` types and write them into `TopologyGroupOfGroups` file. Endpoints are written in `TopologyGroupOfEndpoints` file.
+
+##### Data feeds
+
+Source of the data for other connectors like `weights-gstat-connector.py` and `downtimes-gocdb-connector.py` are optional and can be specified per job. If specified, they will override their default source of data. Example:
+
+	[JOB_BioMedCritical]
+	Dirname = BioMed_Critical
+	Profiles = ROC_CRITICAL
+	TopoType = VOFeed
+	TopoFeed = %(BioMed)s
+	TopoSelectGroupOfGroups = Type:(OPS_Tier, OPS_Site)
+	WeightsFeed = http://gstat2.grid.sinica.edu.tw/gstat/summary/json/ 
+	DowntimesFeed = https://goc.egi.eu/gocdbpi/
+
+`WeightsFeed` and `DowntimesFeed` are alternative data feeds for this job for connectors `weights-gstat-connector.py` and `downtimes-gocdb-connector.py`, respectively.
+
+<a id="sync3"></a>
+
+### poem-connector.conf
+
+This configuration file is central configuration for `poem-connector.py` whose role is:
+
+- fetch all defined POEM profiles from each POEM server specified
+- prepare and layout data needed for `prefilter-egi.py`
+
+#### POEM profiles fetch
+
+Config file is splitted into a few sections:
+
+	[PoemServer]
+	Host = snf-624922.vm.okeanos.grnet.gr
+	VO = ops
+
+This section defines the URL where POEM server is located and all VOes for which POEM profiles will be fetched. Multiple POEM servers can be specified by defining multiple POEM server sections:
+
+	[PoemServer1]
+	Host = poem1
+	VO = vo1, vo2
+
+	[PoemServer2]
+	Host = poem2
+	VO = vo3, vo4
+
+Same POEM profile can be defined on multiple POEM servers. Each POEM server can further extend it with a custom combinations of metrics and service flavours. To distinguish POEM profile defined on multiple POEM servers, namespace must be used. One must be aware of the namespace that POEM server exposes and specify it in `FetchProfiles` section:
+
+	[FetchProfiles]
+	List = CH.CERN.SAM.ROC, CH.CERN.SAM.ROC_OPERATORS, CH.CERN.SAM.ROC_CRITICAL, CH.CERN.SAM.OPS_MONITOR, CH.CERN.SAM.OPS_MONITOR_CRITICAL, CH.CERN.SAM.GLEXEC, CH.CERN.SAM.CLOUD-MON
+
+#### Prefilter data
+
+`poem-connector.py` also generates plaintext `PrefilterPoem` file (specified in `global.conf`) on a daily basis for each customer and places it under customer's directory. Content of the file is controlled in `[PrefilterData]` section:
+
+	[PrefilterData]
+	AllowedNGI = http://mon.egi.eu/nagios-roles.conf
+	AllowedNGIProfiles = ch.cern.sam.ROC, ch.cern.sam.ROC_OPERATORS, ch.cern.sam.ROC_CRITICAL, ch.cern.sam.GLEXEC
+	AllNGI1 = opsmon.egi.eu
+	AllNGIProfiles1 = ch.cern.sam.OPS_MONITOR, ch.cern.sam.OPS_MONITOR_CRITICAL
+	AllNGI2 = cloudmon.egi.eu
+	AllNGIProfiles2 = ch.cern.sam.CLOUD-MON
+
+`AllowedNGI` option defines remote config file that states all allowed NGIes and corresponding nagios boxes. All of them will be expanded and listed together with the information from `AllowedNGIProfiles` POEM profiles (metrics, service flavours, VOes). 
+
+`AllNGI1` option is similar in sense that it will extended specified nagios box (monitoring instance) with the information from `AllNGIProfiles1` POEM profiles. Multiple `AllNGI*` options can be specified and they must come in pair fashion so for every `AllNGI[n]` option, there must exist `AllNGIProfiles[n]` option that is related to it.
+
+With all these informations written in `PrefilterPoem` file, `prefilter-egi.py` can do its work, so it will filter consumer messages if:
+
+- message that enter into broker network doesn't come from allowed NGI or nagios box for certain NGI is incorrectly specified
+- metric result is response to metric not found in a fetched service flavour
+- metric result's service flavour is not registered in any fetched POEM profile
+- metric result is registered for different VO, not specified in `VO` option of any `[PoemServer]` section
+
+## Examples
+
+<div role="tabpanel">
+
+  <!-- Nav tabs -->
+  <ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class="active"><a href="#customer.conf" aria-controls="customer.conf" role="tab" data-toggle="tab">customer.conf</a></li>
+    <li role="presentation"><a href="#customer-jobs" aria-controls="customer-jobs" role="tab" data-toggle="tab">Customer jobs</a></li>
+    <li role="presentation"><a href="#prefilterdata" aria-controls="prefilterdata" role="tab" data-toggle="tab">Prefilter data</a></li>
+    <li role="presentation"><a href="#JOB_Critical" aria-controls="JOB_Critical" role="tab" data-toggle="tab">EGI JOB_Critical</a></li>
+    <li role="presentation"><a href="#JOB_Cloudmon" aria-controls="JOB_Cloudmon" role="tab" data-toggle="tab">EGI JOB_Cloudmon</a></li>
+    <li role="presentation"><a href="#JOB_BioMedCritical" aria-controls="JOB_BioMedCritical" role="tab" data-toggle="tab">JOB_BioMedCritical</a></li>
+    <li role="presentation"><a href="#JOB_BioMedCloudmon" aria-controls="JOB_BioMedCloudmon" role="tab" data-toggle="tab">VO JOB_BioMedCloudmon</a></li>
+    <li role="presentation"><a href="#downtimes" aria-controls="downtimes" role="tab" data-toggle="tab">Downtimes</a></li>
+  </ul>
+
+  <!-- Tab panes -->
+  <div class="tab-content">
+    <div role="tabpanel" class="tab-pane active" id="customer.conf">
+<p>&nbsp;</p>
+<strong>customer.conf:</strong>
+<p>&nbsp;</p>
+<pre>
+	[DEFAULT]
+	BioMed = http://kosjenka.srce.hr/~eimamagi/ops.feed.xml
+
+	[DIR]
+	OutputDir = /var/lib/argo-connectors/EGI/
+
+	[CUSTOMER_EGI]
+	Jobs = JOB_EGICritical, JOB_EGICloudmon, JOB_BioMedCloudmon, JOB_BioMedCritical
+
+	[JOB_EGICritical]
+	Dirname = EGI_Critical
+	Profiles = ROC_CRITICAL
+	TopoType = GOCDB
+	TopoFetchType = Sites
+	#TopoSelectGroupOfEndpoints = Production:Y, Monitored:Y, Scope:EGI
+	TopoSelectGroupOfGroups = Certification:Uncertified, Infrastructure:Test, Scope:EGI
+
+	[JOB_EGICloudmon]
+	Dirname = EGI_Cloudmon
+	Profiles = CLOUD-MON
+	TopoType = GOCDB
+	TopoFetchType = ServiceGroups
+	TopoSelectGroupOfEndpoints = Monitored:Y, Scope:EGI, Production:N
+	#TopoSelectGroupOfGroups = Monitored:Y, Scope:EGI
+
+	[JOB_BioMedCritical]
+	Dirname = BioMed_Critical
+	Profiles = ROC_CRITICAL
+	TopoType = VOFeed
+	TopoFeed = %(BioMed)s
+	TopoSelectGroupOfGroups = Type:OPS_Site
+
+	[JOB_BioMedCloudmon]
+	Dirname = BioMed_Cloudmon
+	Profiles = CLOUD-MON
+	TopoType = VOFeed
+	TopoFeed = %(BioMed)s
+	#TopoSelectGroupOfGroups = Type:OPS_Tier
+</pre>
+
+    </div>
+    <div role="tabpanel" class="tab-pane" id="customer-jobs">
+
+<p>&nbsp;</p>
+<strong>Customer jobs:</strong>
+<p>&nbsp;</p>
+<pre>
+	/var/lib/argo-connectors/EGI/BioMed_Cloudmon/group_endpoints_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/BioMed_Cloudmon/group_groups_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/BioMed_Cloudmon/poem_sync_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/BioMed_Cloudmon/weights_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/BioMed_Critical/group_endpoints_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/BioMed_Critical/group_groups_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/BioMed_Critical/poem_sync_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/BioMed_Critical/weights_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/EGI_Cloudmon/group_endpoints_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/EGI_Cloudmon/group_groups_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/EGI_Cloudmon/poem_sync_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/EGI_Cloudmon/weights_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/EGI_Critical/group_endpoints_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/EGI_Critical/group_groups_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/EGI_Critical/poem_sync_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/EGI_Critical/weights_2015_04_07.avro
+</pre>
+
+    </div>
+    <div role="tabpanel" class="tab-pane" id="prefilterdata">
+
+<p>&nbsp;</p>
+
+<strong>Prefilter data:</strong>
+
+<p>&nbsp;</p>
+<pre>
+
+	/var/lib/argo-connectors/EGI/poem_sync_2015_04_07.out
+	/var/lib/argo-connectors/EGI/prefilter_2015_04_07.avro
+
+</pre>
+</div>
+ <div role="tabpanel" class="tab-pane" id="JOB_Critical">
+
+<p>&nbsp;</p>
+For customer's job JOB_EGICritical, we are selecting only those sites that match `Certification:Uncertified`,  `Infrastructure:Test` and `Scope:EGI`, so in `TopologyGroupOfGroups` file there will be only those sites listed:
+<p>&nbsp;</p>
+<pre>
+	 % avro cat /var/lib/argo-connectors/EGI/EGI_Critical/group_groups_2015_04_07.avro | tail -n 1
+	 {"group": "Russia", "tags": {"scope": "EGI", "infrastructure": "Test", "certification": "Uncertified"}, "type": "NGI", "subgroup": "SU-Protvino-IHEP"}
+</pre>
+<p>&nbsp;</p>
+    </div>
+    <div role="tabpanel" class="tab-pane" id="JOB_Cloudmon">
+<p>&nbsp;</p>
+ For customer's JOB_EGICloudmon, we are selecting only those service endpoints that match `Monitored:Y`, `Scope:EGI`, `Production:N`:
+
+<p>&nbsp;</p>
+
+<pre>	 % avro cat /var/lib/argo-connectors/EGI/EGI_Cloudmon/group_endpoints_2015_04_07.avro
+	 {"group": "ROC_RU_SERVICE", "hostname": "ce.ngc6475.ihep.su", "type": "SERVICEGROUPS", "service": "Top-BDII", "tags": {"scope": "EGI", "production": 0, "monitored": 1}}
+</pre>
+
+<p>&nbsp;</p>
+</div>
+    <div role="tabpanel" class="tab-pane" id="JOB_BioMedCritical">
+<p>&nbsp;</p>
+JOB_BioMedCritical is taking into account only OPS\_Site VO groups:
+<p>&nbsp;</p>
+<pre>
+	% avro cat /var/lib/argo-connectors/EGI/BioMed_Critical/group_groups_2015_04_07.avro | tail -n 5
+	{"group": "SAMPA", "tags": null, "type": "OPS_Site", "subgroup": "SAMPA"}
+	{"group": "UPJS-Kosice", "tags": null, "type": "OPS_Site", "subgroup": "UPJS-Kosice"}
+	{"group": "GR-06-IASA", "tags": null, "type": "OPS_Site", "subgroup": "GR-06-IASA"}
+	{"group": "FI_HIP_T2", "tags": null, "type": "OPS_Site", "subgroup": "FI_HIP_T2"}
+	{"group": "UKI-SOUTHGRID-RALPP", "tags": null, "type": "OPS_Site", "subgroup": "UKI-SOUTHGRID-RALPP"}
+
+</pre>
+<p>&nbsp;</p>
+</div>
+   <div role="tabpanel" class="tab-pane" id="JOB_BioMedCloudmon">
+<p>&nbsp;</p>
+JOB_BioMedCloudmon requires only CLOUD-MON POEM profile so in `Poem` file you have:
+<p>&nbsp;</p>
+<pre>
+	 % avro cat  /var/lib/argo-connectors/EGI/BioMed_Cloudmon/poem_sync_2015_04_07.avro | tail -n 5
+	 {"profile": "ch.cern.sam.CLOUD-MON", "metric": "eu.egi.cloud.Perun-Check", "service": "egi.Perun", "tags": {"fqan": "", "vo": "ops"}}
+	 {"profile": "ch.cern.sam.CLOUD-MON", "metric": "eu.egi.cloud.APEL-Pub", "service": "eu.egi.cloud.accounting", "tags": {"fqan": "", "vo": "ops"}}
+	 {"profile": "ch.cern.sam.CLOUD-MON", "metric": "org.nagios.Broker-TCP", "service": "eu.egi.cloud.broker.compss", "tags": {"fqan": "", "vo": "ops"}}
+	 {"profile": "ch.cern.sam.CLOUD-MON", "metric": "org.nagios.Broker-TCP", "service": "eu.egi.cloud.broker.proprietary.slipstream", "tags": {"fqan": "", "vo": "ops"}}
+	 {"profile": "ch.cern.sam.CLOUD-MON", "metric": "org.nagios.Broker-TCP", "service": "eu.egi.cloud.broker.vmdirac", "tags": {"fqan": "", "vo": "ops"}}
+</pre>
+<p>&nbsp;</p>
+</div>
+
+<div role="tabpanel" class="tab-pane" id="downtimes">
+<p>&nbsp;</p>
+<strong>Downtimes:</strong>
+<p>&nbsp;</p>
+<pre>
+	% /usr/libexec/argo-egi-connectors/downtimes-gocdb-connector.py -d 2015-04-07
+	% find /var/lib/argo-connectors -name '*downtimes*'
+	/var/lib/argo-connectors/EGI/EGI_Cloudmon/downtimes_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/EGI_Critical/downtimes_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/BioMed_Cloudmon/downtimes_2015_04_07.avro
+	/var/lib/argo-connectors/EGI/BioMed_Critical/downtimes_2015_04_07.avro
+</pre>
+</div>
+  </div>
+
+</div>
+
+## Links
+
+Connectors are using following GOCDB PI methods:
+
+- [GOCDB - get_downtime_method](https://wiki.egi.eu/wiki/GOCDB/PI/get_downtime_method)
+- [GOCDB - get_service_endpoint_method](https://wiki.egi.eu/wiki/GOCDB/PI/get_service_endpoint_method)
+- [GOCDB - get_service_group](https://wiki.egi.eu/wiki/GOCDB/PI/get_service_group)
+- [GOCDB - get_site_method](https://wiki.egi.eu/wiki/GOCDB/PI/get_site_method)
+
+[Construction of VO feeds](https://twiki.cern.ch/twiki/bin/view/Main/ATPVOFeeds)

--- a/etc/global.conf
+++ b/etc/global.conf
@@ -2,6 +2,8 @@
 SchemaDir = /etc/argo-egi-connectors/schemas/
 
 [Authentication]
+VerifyServerCert = False
+CAPath = /etc/grid-security/certificates
 HostKey = /etc/grid-security/hostkey.pem
 HostCert = /etc/grid-security/hostcert.pem
 

--- a/modules/tools.py
+++ b/modules/tools.py
@@ -1,0 +1,62 @@
+import logging, logging.handlers
+import sys
+import re
+import socket
+import signal
+
+from OpenSSL.SSL import TLSv1_METHOD, Context, Connection
+from OpenSSL.SSL import VERIFY_PEER, VERIFY_FAIL_IF_NO_PEER_CERT
+from OpenSSL.SSL import Error as SSLError
+from OpenSSL.SSL import OP_NO_SSLv3
+
+def errmsg_from_excp(e):
+    if getattr(e, 'message', False):
+        retstr = ''
+        if isinstance(e.message, list) or isinstance(e.message, tuple) \
+                or isinstance(e.message, dict):
+            for s in e.message:
+                if isinstance(s, str):
+                    retstr += s + ' '
+                if isinstance(s, tuple) or isinstance(s, tuple):
+                    retstr += ' '.join(s)
+            return retstr
+        elif isinstance(e.message, str):
+            return e.message
+        else:
+            for s in e.message:
+                retstr += str(s) + ' '
+            return retstr
+    else:
+        return str(e)
+
+def verify_cert(host, capath, timeout):
+    server_ctx = Context(TLSv1_METHOD)
+    server_ctx.load_verify_locations(None, capath)
+
+    def verify_cb(conn, cert, errnum, depth, ok):
+        return ok
+    server_ctx.set_verify(VERIFY_PEER|VERIFY_FAIL_IF_NO_PEER_CERT, verify_cb)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((host, 443))
+
+    server_conn = Connection(server_ctx, sock)
+    server_conn.set_connect_state()
+
+    def handler(signum, frame):
+        raise socket.error([('Timeout', 'after', str(timeout) + 's')])
+    signal.signal(signal.SIGALRM, handler)
+    signal.alarm(timeout)
+    signal.alarm(0)
+    try:
+        server_conn.do_handshake()
+    except SSLError as e:
+        if 'sslv3 alert handshake failure' in errmsg_from_excp(e):
+            pass
+        else:
+            raise SSLError(e.message)
+
+    server_conn.shutdown()
+    server_conn.close()
+
+    return True


### PR DESCRIPTION
- filter SRM endpoints too 
- refactored use of logging
- connectors can verify server certificate
  https://github.com/ARGOeu/ARGO/issues/153
- report correct number of fetched endpoints even if SRM endpoints were being filtered
- connectors handle help argument and describe basic info and usage
  https://github.com/ARGOeu/ARGO/issues/169
- removed hardcoded scopes and grab them dynamically from config
  https://github.com/ARGOeu/ARGO/issues/168
- report config parser errors via logger
- downtimes connector complain if wrong date specified
- remove notion of default scope
- doc moved to repo
- updated doc with server's cert validate options