### PR TITLE
scopes per feed

### DIFF
--- a/argo-egi-connectors.spec
+++ b/argo-egi-connectors.spec
@@ -1,6 +1,6 @@
 Name: argo-egi-connectors
 Version: 1.4.4
-Release: 2%{?dist}
+Release: 3%{?dist}
 
 Group: EGI/SA4
 License: ASL 2.0

--- a/argo-egi-connectors.spec
+++ b/argo-egi-connectors.spec
@@ -46,7 +46,9 @@ rm -rf $RPM_BUILD_ROOT
 %attr(0750,root,root) %dir %{_localstatedir}/log/argo-egi-connectors/
 
 %changelog
-* Fri Oct 6 2015 Daniel Vrcic <dvrcic@srce.hr> - 1.4.4-2%{?dist}
+* Wed Oct 7 2015 Daniel Vrcic <dvrcic@srce.hr> - 1.4.4-3%{?dist}
+- grab all distinct scopes for feed
+* Tue Oct 6 2015 Daniel Vrcic <dvrcic@srce.hr> - 1.4.4-2%{?dist}
 - fix initialization of loggers in config parsers
 - backward compatible exception messages
 * Fri Oct 2 2015 Daniel Vrcic <dvrcic@srce.hr> - 1.4.4-1%{?dist}

--- a/bin/topology-gocdb-connector.py
+++ b/bin/topology-gocdb-connector.py
@@ -296,12 +296,12 @@ def main():
     confcust = CustomerConf(sys.argv[0])
     confcust.parse()
     confcust.make_dirstruct()
-    scopes = confcust.get_allspec_scopes(sys.argv[0], 'GOCDB')
     feeds = confcust.get_mapfeedjobs(sys.argv[0], 'GOCDB', deffeed='https://goc.egi.eu/gocdbpi/')
 
     timestamp = datetime.datetime.utcnow().strftime('%Y_%m_%d')
 
     for feed, jobcust in feeds.items():
+        scopes = confcust.get_feedscopes(feed, jobcust)
         gocdb = GOCDBReader(feed, scopes)
 
         for job, cust in jobcust:

--- a/modules/config.py
+++ b/modules/config.py
@@ -304,20 +304,18 @@ class CustomerConf:
             feeds[feedurl] = []
             feeds[feedurl].append((job, cust))
 
-    def get_allspec_scopes(self, caller, name=None):
-        distinct_scopes = set()
+    def get_feedscopes(self, feed, jobcust):
         ggtags, getags = [], []
-        for c in self.get_customers():
-            for job in self.get_jobs(c):
-                if self._get_toponame(job) == name:
-                    gg = self._get_tags(job, 'TopoSelectGroupOfGroups')
-                    ge = self._get_tags(job, 'TopoSelectGroupOfEndpoints')
-                    for g in gg.items() + ge.items():
-                        if 'Scope'.lower() == g[0].lower():
-                            if isinstance(g[1], list):
-                                distinct_scopes.update(g[1])
-                            else:
-                                distinct_scopes.update([g[1]])
+        distinct_scopes = set()
+        for job, cust in jobcust:
+            gg = self._get_tags(job, 'TopoSelectGroupOfGroups')
+            ge = self._get_tags(job, 'TopoSelectGroupOfEndpoints')
+            for g in gg.items() + ge.items():
+                if 'Scope'.lower() == g[0].lower():
+                    if isinstance(g[1], list):
+                        distinct_scopes.update(g[1])
+                    else:
+                        distinct_scopes.update([g[1]])
 
         return distinct_scopes
 


### PR DESCRIPTION
As @pkoro noticed, it's slightly incorrect to grab all scopes for all job definitions since jobs can define its own GOCDB-like feed that comes with different set of scopes.

Same feed can be used by several different customers so I think it's better that we find out all specified scopes for defined feed across all customers and jobs. What do you think /cc @pkoro?