### PR TITLE
ARGO-1428 ServiceGroup topology filtering

### DIFF
--- a/bin/topology-gocdb-connector.py
+++ b/bin/topology-gocdb-connector.py
@@ -346,16 +346,17 @@ class TopoFilter(object):
         self.ge = ge
         self.ggfilter = copy.copy(ggfilter)
         self.gefilter = copy.copy(gefilter)
-        self.sitefilter = self.extract_filter('site', self.ggfilter)
-        self.ngifilter = self.extract_filter('ngi', self.ggfilter)
+        self.subgroupfilter = self.extract_filter('site', self.ggfilter) or \
+            self.extract_filter('servicegroup', self.ggfilter)
+        self.groupfilter = self.extract_filter('ngi', self.ggfilter)
         self.topofilter()
 
     def topofilter(self):
-        if self.sitefilter:
-            self.gg = filter(lambda e: e['subgroup'].lower() in self.sitefilter, self.gg)
+        if self.subgroupfilter:
+            self.gg = filter(lambda e: e['subgroup'].lower() in self.subgroupfilter, self.gg)
 
-        if self.ngifilter:
-            self.gg = filter(lambda e: e['group'].lower() in self.ngifilter, self.gg)
+        if self.groupfilter:
+            self.gg = filter(lambda e: e['group'].lower() in self.groupfilter, self.gg)
 
         if self.ggfilter:
             self.gg = self.filter_tags(self.ggfilter, self.gg)

--- a/doc/egi-connectors.md
+++ b/doc/egi-connectors.md
@@ -220,10 +220,11 @@ Tags for selecting group of endpoints are:
 * Monitored = `{Y, N}`
 * Scope = `{EGI, Local}`
 
-Additionally, topology can be filtered for certain NGI or Site and since they are part of group of groups abstract, those should be specified in `TopoSelectGroupOfGroups` option. Examples:
+Additionally, topology can be filtered for certain NGI, Site or ServiceGroup and since they are part of group of groups abstract, those should be specified in `TopoSelectGroupOfGroups` option. Multiple entities can be specified by putting them in parenthesis and separating by comma. Examples:
 
     TopoSelectGroupOfGroups = NGI:EGI.eu
     TopoSelectGroupOfGroups = Site:egee.srce.hr
+    TopoSelectGroupOfGroups = ServiceGroup:(egee.irb.hr,egee.srce.hr)
 
 ##### Data feeds
 


### PR DESCRIPTION
* introduced `TopoSelectGroupOfGroups = ServiceGroup:(egee.irb.hr,egee.srce.hr)` topology filtering job configuratio option 