### PR TITLE
ARGO-3521  Retry on empty responses

### DIFF
--- a/modules/io/http.py
+++ b/modules/io/http.py
@@ -77,7 +77,7 @@ class SessionWithRetry(object):
                             else:
                                 return content
                         else:
-                            raise ConnectorParseError('HTTP Empty response')
+                            self.logger.warn('HTTP Empty response')
 
                 # do not retry on SSL errors, exit immediately
                 except ssl.SSLError as exc:


### PR DESCRIPTION
Accidentally removed in previous PR, revert back to previous behaviour as we want to retry HTTP connections on empty responses with ok HTTP statuses.